### PR TITLE
Update css to show the full length of the log file path

### DIFF
--- a/frontend/scss/main.scss
+++ b/frontend/scss/main.scss
@@ -367,6 +367,8 @@ input::placeholder {
   .multiselect__content-wrapper {
       border: 0;
       border-radius: 0;
+      width: auto;
+      min-width: 100%;
   }
 }
 


### PR DESCRIPTION
The proposed changes makes it so that the dropdown menu is expanded to show the FULL path of the log file.
Before this change, long logfile paths were being cropped.

<img width="1440" alt="before" src="https://user-images.githubusercontent.com/13037215/45924483-bd16f300-bec6-11e8-8ae6-1af5950de62e.png">
<img width="1440" alt="after" src="https://user-images.githubusercontent.com/13037215/45924484-bd16f300-bec6-11e8-831c-846c64362386.png">
