### PR TITLE
Install different awk, sed, and grep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ FROM alpine:3.7
 WORKDIR /tailon
 COPY --from=build /go/src/github.com/gvalkov/tailon/tailon /usr/local/bin/tailon
 
+RUN unlink /usr/bin/awk && unlink /bin/grep && unlink /bin/sed
+RUN apk add gawk grep sed
+
 CMD        ["--help"]
 ENTRYPOINT ["/usr/local/bin/tailon"]
 EXPOSE 8080


### PR DESCRIPTION
The alpine container uses busybox which is missing some of the default options Fixes #2.