### PR TITLE
is length not capacity

### DIFF
--- a/main.go
+++ b/main.go
@@ -279,7 +279,7 @@ func main() {
 	config.RelativeRoot = strings.TrimRight(config.RelativeRoot, "/") + "/"
 
 	// Handle command-line file specs
-	filespecs := make([]FileSpec, len(flag.Args()))
+	filespecs := make([]FileSpec, 0, len(flag.Args()))
 	for _, spec := range flag.Args() {
 		if filespec, err := parseFileSpec(spec); err != nil {
 			fmt.Fprintf(os.Stderr, "Error parsing argument '%s': %s\n", spec, err)


### PR DESCRIPTION
Thank you for your project！My english is poor,but code is good.In go make slice the second args is meaning init length,not capacity.It run ok,but I find config.FileSpecs hava empty element.